### PR TITLE
Stop click event propagation on CID ID lists

### DIFF
--- a/app/views/directives/centreGender.html
+++ b/app/views/directives/centreGender.html
@@ -45,7 +45,7 @@
       <td>
         Expected incoming
         <h4 ng-if="showIncoming">CID number</h4>
-        <ul ng-if="showIncoming">
+        <ul ng-if="showIncoming" ng-click="$event.stopPropagation()">
           <li ng-repeat="theExpectedin in expectedin">{{theExpectedin.cid_id}}</li>
         </ul>
       </td>
@@ -58,7 +58,7 @@
       <td>
         Unexpected incoming
         <h4 ng-if="showUnexpectedIncoming">CID number</h4>
-        <ul ng-if="showUnexpectedIncoming">
+        <ul ng-if="showUnexpectedIncoming" ng-click="$event.stopPropagation()">
           <li ng-repeat="theUnexpectedin in unexpectedin">{{theUnexpectedin.cid_id}}</li>
         </ul>
       </td>
@@ -77,7 +77,7 @@
       <td>
         Expected outgoing
         <h4 ng-if="showExpectedOutgoing">CID number</h4>
-        <ul ng-if="showExpectedOutgoing">
+        <ul ng-if="showExpectedOutgoing" ng-click="$event.stopPropagation()">
           <li ng-repeat="theExpectedout in expectedout">{{theExpectedout.cid_id}}</li>
         </ul>
       </td>


### PR DESCRIPTION
Added an `ng-click` listener to the CID ID lists, that consumes click events on the CIDs, allowing the user to select them for copying.

![image](https://cloud.githubusercontent.com/assets/7834222/16199418/5d50c440-3701-11e6-8b5e-3ef7d10326b0.png)
